### PR TITLE
Fix Account.get_transactions to give right values to user

### DIFF
--- a/qifparse/qif.py
+++ b/qifparse/qif.py
@@ -307,7 +307,7 @@ class Account(BaseEntry):
     account_type = property(get_type, set_type)
 
     def get_transactions(self):
-        return tuple(self._transactions)
+        return tuple(self._transactions.values())
 
     def __str__(self):
         res = []


### PR DESCRIPTION
As long as 'transactions' is a hash then to get actual values
from it we should call 'obj._transactions.values()', not just
'obj._transactions'.
There are also no risk to do so, cause one account can actually
have only one kind of a 'type'.