### PR TITLE
Added fixes for QIF files with different date order and syntax

### DIFF
--- a/qifparse/parser.py
+++ b/qifparse/parser.py
@@ -74,7 +74,7 @@ class QifParser(object):
             if not chunk:
                 continue
             first_line = chunk.split('\n')[0]
-            first_line = first_line.rstrip()
+            first_line = first_line.strip()
             if first_line == '!Type:Cat':
                 last_type = 'category'
             elif first_line == '!Account':
@@ -364,9 +364,22 @@ class QifParser(object):
         for i in range(len(qdate)):
             if qdate[i] == " ":
                 qdate = qdate[:i] + "0" + qdate[i+1:]
+
         if len(qdate) == 10:  # new form with YYYY date
-            iso_date = qdate[6:10] + "-" + qdate[3:5] + "-" + qdate[0:2]
-            return datetime.strptime(iso_date, '%Y-%m-%d')
+            year = qdate[6:10]
+            if cls_._months_first:
+                month = qdate[0:2]
+                day = qdate[3:5]
+            else:
+                month = qdate[3:5]
+                day = qdate[0:2]
+            iso_date = year + "-" + month + "-" + day
+            try:
+                dtime = datetime.strptime(iso_date, '%Y-%m-%d')
+            except:
+                raise ValueError("ERROR in time format QIF(%s) ISO(%s)" % (qdate, iso_date))
+            return dtime
+
         if qdate[5] == "'":
             C = "20"
         else:

--- a/qifparse/parser.py
+++ b/qifparse/parser.py
@@ -225,7 +225,7 @@ class QifParser(object):
                 split.address.append(line[1:])
             elif line[0] == '$':
                 split = curItem.splits[-1]
-                split.amount = Decimal(line[1:])
+                split.amount = convertFloat(line[1:])
             else:
                 # don't recognise this line; ignore it
                 print ("Skipping unknown line:\n" + str(line))
@@ -297,7 +297,8 @@ class QifParser(object):
                 split.address.append(line[1:])
             elif line[0] == '$':
                 split = curItem.splits[-1]
-                split.amount = convertFloat(line[1:-1])
+                # split.amount = convertFloat(line[1:-1])
+                split.amount = "%.2f" % convertFloat(line[1:-1])
             else:
                 # don't recognise this line; ignore it
                 print ("Skipping unknown line:\n" + str(line))
@@ -318,7 +319,7 @@ class QifParser(object):
             elif line[0] == 'D':
                 curItem.date = cls_.parseQifDateTime(line[1:])
             elif line[0] == 'T':
-                curItem.amount = Decimal(line[1:])
+                curItem.amount = convertFloat(line[1:])
             elif line[0] == 'N':
                 curItem.action = line[1:]
             elif line[0] == 'Y':

--- a/qifparse/parser.py
+++ b/qifparse/parser.py
@@ -41,11 +41,16 @@ class QifParser(object):
     _thousands_separator = ','
 
     @classmethod
-    def parse(cls_, file_handle, date_format=None, months_first=None, thousands_separator=None):
+    def parse(cls_, file_handle, date_format=None,
+              months_first=None,
+              thousands_separator=None,
+              currency_num_fractional_digits=None):
         if months_first is not None:
             cls_._months_first = months_first
         if thousands_separator is not None:
             cls_._thousands_separator = thousands_separator
+        if currency_num_fractional_digits is not None:
+            Qif.set_currency_num_fractional_digits(int(currency_num_fractional_digits))
         if isinstance(file_handle, type('')):
             raise RuntimeError(
                 six.u("parse() takes in a file handle, not a string"))
@@ -249,6 +254,8 @@ class QifParser(object):
                 curItem.num = line[1:]
             elif line[0] == 'T':
                 curItem.amount = convertFloat(line[1:])
+            elif line[0] == 'U':
+                curItem.amount_U = convertFloat(line[1:])
             elif line[0] == 'C':
                 curItem.cleared = line[1:]
             elif line[0] == 'P':

--- a/qifparse/parser.py
+++ b/qifparse/parser.py
@@ -297,8 +297,7 @@ class QifParser(object):
                 split.address.append(line[1:])
             elif line[0] == '$':
                 split = curItem.splits[-1]
-                # split.amount = convertFloat(line[1:-1])
-                split.amount = "%.2f" % convertFloat(line[1:-1])
+                split.amount = convertFloat(line[1:-1])
             else:
                 # don't recognise this line; ignore it
                 print ("Skipping unknown line:\n" + str(line))

--- a/qifparse/qif.py
+++ b/qifparse/qif.py
@@ -185,7 +185,7 @@ class Transaction(BaseEntry):
     _fields = [
         Field('date', 'datetime', 'D', required=True, default=datetime.now()),
         Field('num', 'string', 'N'),
-        Field('amount', 'decimal', 'T', required=True),
+        Field('amount', 'decimal', 'T', required=True, custom_print_format='%s%.2f'),
         Field('cleared', 'string', 'C'),
         Field('payee', 'string', 'P'),
         Field('memo', 'string', 'M'),
@@ -240,7 +240,7 @@ class AmountSplit(BaseEntry):
     _fields = [
         Field('category', 'string', 'S'),
         Field('to_account', 'reference', 'S'),
-        Field('amount', 'decimal', '$'),
+        Field('amount', 'decimal', '$', custom_print_format='%s%.2f'),
         Field('percent', 'string', '%'),
         Field('address', 'multilinestring', 'A'),
         Field('memo', 'string', 'M'),

--- a/qifparse/qif.py
+++ b/qifparse/qif.py
@@ -23,6 +23,9 @@ MEMORIZED_TRANSACTION_TYPES = [
 
 
 class Qif(object):
+
+    _currency_format = '%.2f'
+
     def __init__(self):
         self._accounts = []
         self._categories = []
@@ -102,6 +105,17 @@ class Qif(object):
             tr.extend(self._transactions.values)
             for acc in self._accounts:
                 tr.extend(acc.transactions)
+
+    @classmethod
+    def set_currency_num_fractional_digits(cls, num):
+        """Set the number of digits in the fractional part of currency values 
+           (for __str__ output)"""
+        cls._currency_format = "%%.%df" % int(num)
+        print("  CUR FORM: ", Qif._currency_format)
+
+    @classmethod
+    def currency_format(cls):
+        return cls._currency_format
 
     def __str__(self):
         res = []
@@ -185,7 +199,10 @@ class Transaction(BaseEntry):
     _fields = [
         Field('date', 'datetime', 'D', required=True, default=datetime.now()),
         Field('num', 'string', 'N'),
-        Field('amount', 'decimal', 'T', required=True, custom_print_format='%s%.2f'),
+        Field('amount', 'decimal', 'T', required=True,
+              custom_print_format='%s' + Qif.currency_format()),
+        Field('amount_U', 'decimal', 'U',
+              custom_print_format='%s' + Qif.currency_format()),
         Field('cleared', 'string', 'C'),
         Field('payee', 'string', 'P'),
         Field('memo', 'string', 'M'),
@@ -240,7 +257,8 @@ class AmountSplit(BaseEntry):
     _fields = [
         Field('category', 'string', 'S'),
         Field('to_account', 'reference', 'S'),
-        Field('amount', 'decimal', '$', custom_print_format='%s%.2f'),
+        Field('amount', 'decimal', '$',
+              custom_print_format='%s' + Qif.currency_format()),
         Field('percent', 'string', '%'),
         Field('address', 'multilinestring', 'A'),
         Field('memo', 'string', 'M'),
@@ -253,7 +271,7 @@ class Investment(BaseEntry):
         Field('date', 'datetime', 'D', required=True, default=datetime.now()),
         Field('action', 'string', 'N'),
         Field('security', 'string', 'Y'),
-        Field('price', 'decimal', 'I', custom_print_format='%s%.3f'),
+        Field('price', 'decimal', 'I', custom_print_format='%s%.3f'),   # Why 3?
         Field('quantity', 'decimal', 'Q', custom_print_format='%s%.3f'),
         Field('cleared', 'string', 'C'),
         Field('amount', 'decimal', 'T'),


### PR DESCRIPTION
I ran into difficulties with QIF files exported by an old version of Quicken.  Some of the numbers had embeded commas (for thousands separators) and the date as in DD/MM'YY format instead of MM/DD'YY format the code expects.   I added a couple of class-level flags for this.  Normal use should not change, but By giving extra (optional) arguments to the .parse() command, it handles my odd formats too.

I changed the Decimal(str) use to use a special function that removes the embedded thousands separators (commas by default, but overrideable) before doing the conversion to a flow.  I only did it where I had difficulties (processing transactions); you may want to change the rest correspondingly.