### PR TITLE
Refactoring of parseQifDateTime method

### DIFF
--- a/qifparse/__init__.py
+++ b/qifparse/__init__.py
@@ -1,2 +1,7 @@
-__version__ = '0.1'
-DEFAULT_DATETIME_FORMAT = '%d/%m/%Y'
+__version__ = '0.6'
+DATETIME_FORMAT = {
+    'YMD': '%Y/%m/%d',
+    'DMY': '%d/%m/%Y',
+    'MDY': '%m/%d/%Y'
+}
+DEFAULT_DATETIME_FORMAT = 'DMY'

--- a/qifparse/parser.py
+++ b/qifparse/parser.py
@@ -364,7 +364,7 @@ class QifParser(object):
             else:
                     date_year = '20' + date_year                    
 
-        iso_date = '{:4d}'.format(int(date_year)) + "-" + \
-                   '{:0>2d}'.format(int(date_month)) + "-" + \
-                   '{:0>2d}'.format(int(date_day)) 
+        iso_date = '{0:4d}'.format(int(date_year)) + "-" + \
+                   '{0:0>2d}'.format(int(date_month)) + "-" + \
+                   '{0:0>2d}'.format(int(date_day)) 
         return datetime.strptime(iso_date, '%Y-%m-%d')

--- a/qifparse/qif.py
+++ b/qifparse/qif.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import six
 from datetime import datetime
-from qifparse import DEFAULT_DATETIME_FORMAT
+from qifparse import DATETIME_FORMAT, DEFAULT_DATETIME_FORMAT
 
 ACCOUNT_TYPES = [
     'Cash',
@@ -141,8 +141,8 @@ class BaseEntry(object):
     _fields = []
     _sub_entry = False
 
-    def __init__(self, **kwargs):
-        self.date_format = DEFAULT_DATETIME_FORMAT
+    def __init__(self, **kwargs):     
+        self.date_format = DATETIME_FORMAT[DEFAULT_DATETIME_FORMAT]
         for field in self._fields:
             val = kwargs.get(field.name, field.default)
             setattr(self, field.name, val)

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@ import os
 from setuptools import setup, find_packages
 
 version = '0.6'
-long_description = open("README.rst").read() + "\n" + \
-    open("CHANGELOG.rst").read()
+long_description = ""
+#long_description = open("README.rst").read() + "\n" + \
+#    open("CHANGELOG.rst").read()
 
 setup(name='qifparse',
       version=version,

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,8 @@ import os
 from setuptools import setup, find_packages
 
 version = '0.6'
-long_description = ""
-#long_description = open("README.rst").read() + "\n" + \
-#    open("CHANGELOG.rst").read()
+long_description = open("README.rst").read() + "\n" + \
+    open("CHANGELOG.rst").read()
 
 setup(name='qifparse',
       version=version,


### PR DESCRIPTION
Date format can be 'DMY', 'MDY' or 'YMD' (defined in __init__). The date format is propagated to all parsers and the format is used to read QIF files (not only in str(qif)).